### PR TITLE
allow multi-line-comment extraction

### DIFF
--- a/lib/typson-schema.js
+++ b/lib/typson-schema.js
@@ -36,7 +36,7 @@ var TypeScript, _, traverse; // from global scope
     //var validationKeywords = ["type", "minimum", "exclusiveMinimum", "maximum", "exclusiveMaximum", "multipleOf",
     //    "minLength", "maxLength", "format", "pattern", "minItems", "maxItems", "uniqueItems", "default",
     //    "additionalProperties", "title"];
-    var annotedValidationKeywordPattern = /@[a-z.]+\s*[^\n]+/gi;
+    var annotedValidationKeywordPattern=/@[a-z\.]+\s+[\s\S]*?((?=\n@)|(?=$))/gi;
     var TypescriptASTFlags = {"optionalName": 4, "arrayType": 8};
     var defaultProperties = {additionalProperties: false};
 
@@ -391,6 +391,7 @@ var TypeScript, _, traverse; // from global scope
     }
 
     function escape(str) {
+        return str;
         return str
             .replace(/[\\]/g, '\\\\')
             .replace(/[\"]/g, '\\\"')

--- a/lib/typson.js
+++ b/lib/typson.js
@@ -109,6 +109,7 @@ var _; // from global scope
     }
 
     function escapeContent(str) {
+        return str;
         return str
             .replace(/[\\]/g, '\\\\')
             .replace(/[\"]/g, '\\\"')


### PR DESCRIPTION
In block comments, multiple line could be spread to match the keyword-value pair as https://regex101.com/r/mN2cT8/1

without escape, we could get 

```
{
        "main": "<h1 class=\"{{ namespaceClass('__title') }}\">{{ labels.get('title') }}</h1>\n<ul>\n<li class=\"first\">01</li>\n<li class='second'>02</li>\n<li>03</li> dfd     f\n<li>04</li>     I am after \\t\n<li>05</li>\n<li>06</li>\n<li>07</li> \\n could be text freely\n<li>08</li>\n<li>09</li>\n<li>10</li>\n</li>"
}
```

JSON.stringify handle the escape of quotes and \ automatically.
